### PR TITLE
Sitemap Bug Fix

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -20,7 +20,7 @@ export default function NotFound() {
 	setRequestLocale("en");
 
 	return (
-		<html data-scroll-behavior="smooth">
+		<html lang="en" data-scroll-behavior="smooth">
 			<body className={`antialiased ${googleSansFlex.className}`}>
 				<Suspense fallback={null}>
 					<NextIntlClientProvider>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,6 +5,8 @@ import { getAllArticles } from "../lib/server-action/news-article";
 export const dynamic = "force-static";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	"use cache";
+
 	const baseUrl = await getBaseURL();
 	const newsArticles = await getAllArticles();
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,23 +1,20 @@
 import type { MetadataRoute } from "next";
-import { getBaseURL } from "../lib/server-action/miscellaneous";
 import { getAllArticles } from "../lib/server-action/news-article";
-
-export const dynamic = "force-static";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	"use cache";
 
-	const baseUrl = await getBaseURL();
+	const baseUrl = "https://www.nativityoftheotokos.com";
 	const newsArticles = await getAllArticles();
 
 	return [
 		{
-			url: "https://www.nativityoftheotokos.com",
+			url: baseUrl,
 			changeFrequency: "daily",
 			priority: 1,
 			alternates: {
 				languages: {
-					ru: "https://www.nativityoftheotokos.com/ru",
+					ru: `${baseUrl}/ru"`,
 				},
 			},
 		},

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,7 +14,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 1,
 			alternates: {
 				languages: {
-					ru: `${baseUrl}/ru"`,
+					ru: `${baseUrl}/ru`,
 				},
 			},
 		},

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,10 +1,8 @@
 import type { MetadataRoute } from "next";
-import { getAllArticles } from "../lib/server-action/news-article";
 import { getBaseURL } from "../lib/server-action/miscellaneous";
-import { headers } from "next/headers";
+import { getAllArticles } from "../lib/server-action/news-article";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	await headers(); //HACK
 	const baseUrl = await getBaseURL();
 	const newsArticles = await getAllArticles();
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 import { getBaseURL } from "../lib/server-action/miscellaneous";
 import { getAllArticles } from "../lib/server-action/news-article";
 
+export const dynamic = "force-static";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = await getBaseURL();
 	const newsArticles = await getAllArticles();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ const nextIntlMiddleware = createMiddleware(routing);
 export default function middleware(req: NextRequest) {
 	const { pathname } = req.nextUrl;
 
-	if (pathname === "/sitemap.xml" || pathname === "/robots.txt") {
+	if (pathname == "/sitemap.xml" || pathname == "/robots.txt") {
 		return NextResponse.next();
 	}
 
@@ -18,5 +18,5 @@ export const config = {
 	// Match all pathnames except for
 	// - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
 	// - … the ones containing a dot (e.g. `favicon.ico`)
-	matcher: "/((?!api|trpc|_next|_vercel|sitemap.xml|.*\\..*).*)",
+	matcher: ["/((?!api|trpc|_next|_vercel|sitemap.xml|.*\\..*).*)"],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ const nextIntlMiddleware = createMiddleware(routing);
 export default function middleware(req: NextRequest) {
 	const { pathname } = req.nextUrl;
 
-	if (pathname.startsWith("/sitemap") || pathname.startsWith("/robots")) {
+	if (pathname === "/sitemap.xml" || pathname === "/robots.txt") {
 		return NextResponse.next();
 	}
 


### PR DESCRIPTION
## Problem
Sitemap.xml metadata route was being intercepted by next-intl middleware in production despite specified rules excluding it.

## Fix
Cached the `sitemap()` function (added `use cache` directive) causing the sitemap to be statically generated at build time.

## Future considerations
Investigate why `/sitemap.xml` was being intercepted by `/[locale]` when dynamically rendered.