### PR TITLE
Fixed flashing loading skeletons on redirect

### DIFF
--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -7,7 +7,7 @@ export default async function Page() {
 		<ProtectedComponent
 			model={newReadonlyModel({
 				roles: ["staff"],
-				signInEndpoint: "/admin",
+				// signInEndpoint: "/admin",
 			})}
 		>
 			<Admin />

--- a/src/app/[locale]/quotes/new/page.tsx
+++ b/src/app/[locale]/quotes/new/page.tsx
@@ -23,8 +23,8 @@ export default function Page() {
 	return (
 		<ProtectedComponent
 			model={newReadonlyModel({
-				signInEndpoint: "/quotes/new",
 				roles: ["quotes"],
+				// signInEndpoint: "/quotes/new",
 			})}
 		>
 			<NewQuoteClient />

--- a/src/lib/utility/auth.ts
+++ b/src/lib/utility/auth.ts
@@ -1,0 +1,3 @@
+export function getProtectedRoutes() {
+	return ["/admin", "/quotes/new"];
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,11 @@
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { NextRequest, NextResponse } from "next/server";
+import { getProtectedRoutes } from "./lib/utility/auth";
+import { getUser } from "./lib/server-action/auth";
 
 const nextIntlMiddleware = createMiddleware(routing);
 
-<<<<<<< HEAD
 export default async function middleware(req: NextRequest) {
 	const { pathname } = req.nextUrl;
 	const user = await getUser();
@@ -16,13 +17,6 @@ export default async function middleware(req: NextRequest) {
 			);
 			return NextResponse.redirect(newUrl);
 		}
-=======
-export default function middleware(req: NextRequest) {
-	const { pathname } = req.nextUrl;
-
-	if (pathname == "/sitemap.xml" || pathname == "/robots.txt") {
-		return NextResponse.next();
->>>>>>> 5c9aec14670165be3403774640efb1ce033dc4c3
 	}
 
 	return nextIntlMiddleware(req);


### PR DESCRIPTION
Had to move the redirect logic from server components to middleware to make it work. Nextjs seems to abort suspense when redirects are called in server components vercel/next.js#57455. Will revisit when Next fixes it in the future maybe.